### PR TITLE
uart: fix transmitter handling

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -188,7 +188,7 @@ impl Uart {
                     lsr |= Uart::LSR_DATA_READY;
                 }
                 if trap::get_mtime() >= self.next_interrupt_time {
-                    lsr |= Uart::LSR_TRANSMITTER_HAS_ROOM | Uart::LSR_BREAK_INTERRUPT;
+                    lsr |= Uart::LSR_TRANSMITTER_HAS_ROOM | Uart::LSR_TRANSMITTER_EMPTY;
                 }
                 lsr
             }


### PR DESCRIPTION
We accidentally set the BREAK_INTERRUPT bit instead of the TRANSMITTER_EMPTY bit, meaning that we'd both lose input characters and waste time in the guest linux kernel spinning to wait for the transmitter fifo to flush after each line. Fix that.

This PR also includes other changes to improve clarity of UART code and adds some unrelated notes on the boot sequence.