### PR TITLE
_start ordering fix and debugging improvements

### DIFF
--- a/.gdbinit
+++ b/.gdbinit
@@ -1,0 +1,5 @@
+echo + target remote localhost:26000\n
+target remote localhost:26000
+
+echo + symbol-file target/riscv64imac-unknown-none-elf/release/rvirt\n
+symbol-file target/riscv64imac-unknown-none-elf/release/rvirt

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,11 @@
 release: src/*.rs Cargo.toml src/linker.ld
 	cargo rustc --release --target riscv64imac-unknown-none-elf -- -C link-arg=-Tsrc/linker.ld  -C linker=riscv64-unknown-elf-ld
 
+GDBOPTS=$(if $(DEBUG),-gdb tcp::26000 -S,)
+
 qemu: release
 	# note: this maps rng -> virtio2, blk -> virtio1, net -> virtio0. see virtio-order.md for explanation.
-	qemu-system-riscv64 -machine virt -kernel target/riscv64imac-unknown-none-elf/release/rvirt -nographic -initrd fedora-vmlinux -m 2G -smp 2 \
+	qemu-system-riscv64 -machine virt -kernel target/riscv64imac-unknown-none-elf/release/rvirt -nographic -initrd fedora-vmlinux -m 2G -smp 2 $(GDBOPTS) \
 	    -object rng-random,filename=/dev/urandom,id=rng0 \
 	    -device virtio-rng-device,rng=rng0,bus=virtio-mmio-bus.0 \
 	    -append "console=ttyS0 ro root=/dev/vda" \
@@ -11,3 +13,7 @@ qemu: release
 	    -drive file=stage4-disk.img,format=raw,id=hd0 \
 	    -device virtio-net-device,netdev=usernet,bus=virtio-mmio-bus.2 \
 	    -netdev user,id=usernet,hostfwd=tcp::10000-:22
+
+# to debug, run make qemu-gdb, and then run gdb
+qemu-gdb: DEBUG=1
+qemu-gdb: qemu

--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ Why not? Rust is a pleasant language to work with and can directly target bare m
          $ make
          $ sudo make install
 
+ - gdb (optional):
+
+   to download and build:
+
+       $ wget https://ftp.gnu.org/gnu/gdb/gdb-8.2.1.tar.xz
+       $ tar -xf gdb-8.2.1.tar.xz gdb-8.2.1/
+       $ cd gdb-8.2.1
+       $ ./configure --target=riscv64-unknown-elf --disable-nls
+       $ make
+       $ sudo make install
+
 ## Instructions
 
 Download RVirt's source code:
@@ -75,6 +86,11 @@ You'll need guest binaries to run RVirt: a kernel binary (vmlinux) and a disk im
 Now you can run with:
 
     $ make qemu
+
+If you want to debug using gdb, run these commands in the project directory in separate shells:
+
+    $ make qemu-gdb
+    $ riscv64-unknown-elf-gdb
 
 ## Current Status
 

--- a/src/linker.ld
+++ b/src/linker.ld
@@ -6,6 +6,7 @@ SECTIONS
   . = 0x80000000;
   .text.init :
   {
+    *(.text.entrypoint)
     *(.text.init)
   }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,8 @@ use pmap::{boot_page_table_pa, pa2va};
 
 /* Start-up sequence summary:
  *  - QEMU loads hypervisor kernel (this program), linux kernel, initrd into memory
- *  - QEMU launches hardcoded mrom reset vector, which jumps to _start via elf entrypoint
+ *  - QEMU launches hardcoded mrom reset vector, which jumps to 0x80000000,
+ *  - _start is located at 0x80000000 as the only function in the .init.entrypoint section
  *  - _start sets up the stack and calls into mstart
  *  - mstart implements the small portion of machine-mode code needed by the hypervisor
  *  - mstart returns into supervisor-mode in sstart
@@ -100,7 +101,7 @@ use pmap::{boot_page_table_pa, pa2va};
 
 #[naked]
 #[no_mangle]
-#[link_section = ".text.init"]
+#[link_section = ".text.entrypoint"]
 unsafe fn _start() {
     asm!("li sp, 0x80a00000
           beqz a0, stack_init_done

--- a/src/riscv.rs
+++ b/src/riscv.rs
@@ -12,6 +12,7 @@ macro_rules! reg {
     };
 }
 
+/** atomic read from CSR */
 #[macro_export]
 macro_rules! csrr {
     ( $r:ident ) => {
@@ -24,6 +25,7 @@ macro_rules! csrr {
     };
 }
 
+/** atomic write to CSR */
 #[macro_export]
 macro_rules! csrw {
     ( $r:ident, $x:expr ) => {
@@ -35,6 +37,7 @@ macro_rules! csrw {
     };
 }
 
+/** atomic write to CSR from immediate */
 #[macro_export]
 macro_rules! csrwi {
     ( $r:ident, $x:expr ) => {
@@ -51,6 +54,7 @@ macro_rules! csrwi {
     };
 }
 
+/** atomic read and set bits in CSR */
 #[macro_export]
 macro_rules! csrs {
     ( $r:ident, $x:expr ) => {
@@ -62,6 +66,7 @@ macro_rules! csrs {
     };
 }
 
+/** atomic read and set bits in CSR using immediate */
 #[macro_export]
 macro_rules! csrsi {
     ( $r:ident, $x:expr ) => {
@@ -78,6 +83,7 @@ macro_rules! csrsi {
     };
 }
 
+/** atomic read and clear bits in CSR */
 #[macro_export]
 macro_rules! csrc {
     ( $r:ident, $x:expr ) => {

--- a/src/trap.rs
+++ b/src/trap.rs
@@ -45,6 +45,18 @@ pub mod constants {
     pub const SATP_PPN: u64 = 0xfff_ffffffff;
 
     pub const SSTACK_BASE: u64 = 0xffffffffc0a00000 - 32*8;
+
+    pub const SCAUSE_INSN_MISALIGNED: u64 = 0;
+    pub const SCAUSE_INSN_ACCESS_FAULT: u64 = 1;
+    pub const SCAUSE_ILLEGAL_INSN: u64 = 2;
+    pub const SCAUSE_BREAKPOINT: u64 = 3;
+    pub const SCAUSE_LOAD_ACCESS_FAULT: u64 = 5;
+    pub const SCAUSE_ATOMIC_MISALIGNED: u64 = 6;
+    pub const SCAUSE_STORE_ACCESS_FAULT: u64 = 7;
+    pub const SCAUSE_ENV_CALL: u64 = 8;
+    pub const SCAUSE_INSN_PAGE_FAULT: u64 = 12;
+    pub const SCAUSE_LOAD_PAGE_FAULT: u64 = 13;
+    pub const SCAUSE_STORE_PAGE_FAULT: u64 = 15;
 }
 use self::constants::*;
 
@@ -171,14 +183,14 @@ pub unsafe fn strap() {
     if (cause as isize) < 0 {
         handle_interrupt(&mut state, cause);
         maybe_forward_interrupt(&mut state, csrr!(sepc));
-    } else if cause == 12 || cause == 13 || cause == 15 {
+    } else if cause == SCAUSE_INSN_PAGE_FAULT || cause == SCAUSE_LOAD_PAGE_FAULT || cause == SCAUSE_STORE_PAGE_FAULT {
         let pc = csrr!(sepc);
         if pfault::handle_page_fault(&mut state, cause, pc) {
             maybe_forward_interrupt(&mut state, pc);
         } else {
             forward_exception(&mut state, cause, pc);
         }
-    } else if cause == 2 && state.smode {
+    } else if cause == SCAUSE_ILLEGAL_INSN && state.smode {
         let pc = csrr!(sepc);
         let (instruction, decoded, len) = decode_instruction_at_address(&mut state, pc);
         let mut advance_pc = true;
@@ -251,7 +263,7 @@ pub unsafe fn strap() {
             csrw!(sepc, pc + len);
         }
         maybe_forward_interrupt(&mut state, csrr!(sepc));
-    } else if cause == 8 && state.smode {
+    } else if cause == SCAUSE_ENV_CALL && state.smode {
         match get_register(state, 17) {
             0 => {
                 state.csrs.sip.set(IP_STIP, false);
@@ -269,7 +281,7 @@ pub unsafe fn strap() {
         }
         csrw!(sepc, csrr!(sepc) + 4);
     } else {
-        if cause != 8 { // no need to print anything for guest syscalls...
+        if cause != SCAUSE_ENV_CALL { // no need to print anything for guest syscalls...
             println!("Forward exception (cause = {}, smode={})!", cause, state.smode);
         } else {
             // println!("system call: {}({:#x}, {:#x}, {:#x}, {:#x})",

--- a/src/trap.rs
+++ b/src/trap.rs
@@ -174,6 +174,14 @@ pub unsafe fn strap() {
         println!("sepc = {:#x}", csrr!(sepc));
         println!("stval = {:#x}", csrr!(stval));
         println!("cause = {}", cause);
+
+        let region: crate::memory_region::MemoryRegion = crate::memory_region::MemoryRegion::with_base_address(SSTACK_BASE, 0, 32 * 8);
+        println!("reg ra = {:#x}", region[1 * 8]);
+        println!("reg sp = {:#x}", csrr!(sscratch));
+        for i in 3..32 {
+            println!("reg x{} = {:#x}", i, region[i * 8]);
+        }
+
         loop {}
     }
 


### PR DESCRIPTION
 - Fix _start being possibly ordered after other methods by introducing a new linker section.
 - Add wrapper script to launch qemu ready for gdb; document debugging
 - Increase debug info printed by hypervisor on trap.
 - Use better names for exception causes for clarity