### PR TITLE
Add machine-mode debugging tool for PMP config

### DIFF
--- a/src/machdebug.rs
+++ b/src/machdebug.rs
@@ -1,0 +1,110 @@
+
+use core::ptr;
+
+// NOTE: you need to call machine_debug_init first if you want to use any of this
+// TODO: remove that requirement
+
+// this might re-init the ns16550a with respect to print.rs's initialization. I hope it's okay.
+#[link_section = ".text.init"]
+pub fn machine_debug_init() {
+    unsafe {
+        ptr::write_volatile(BASE_ADDRESS.offset(1), 0x00);
+        ptr::write_volatile(BASE_ADDRESS.offset(3), 0x80);
+        ptr::write_volatile(BASE_ADDRESS.offset(0), 0x03);
+        ptr::write_volatile(BASE_ADDRESS.offset(1), 0x00);
+        ptr::write_volatile(BASE_ADDRESS.offset(3), 0x03);
+        ptr::write_volatile(BASE_ADDRESS.offset(2), 0xC7);
+    }
+}
+
+// never returns but we can't convince rust of that, because unreachable_unchecked requires abort
+#[link_section = ".text.init"]
+pub fn machine_debug_abort(msg: &str) {
+    machine_debug_mark_begin();
+    machine_debug_puts(msg);
+    machine_debug_puts("\n");
+    machine_debug_mark_end();
+    unsafe {
+        asm!("1: j 1b\n");
+    }
+}
+
+#[link_section = ".text.init"]
+pub fn machine_debug_assert(cond: bool, msg: &str) {
+    if !cond {
+        machine_debug_abort(msg);
+    }
+}
+
+const BASE_ADDRESS: *mut u8 = 0x10000000 as *mut u8;
+
+// assumes ns16550a
+#[link_section = ".text.init"]
+pub fn machine_debug_putchar(ch: u8) {
+    unsafe {
+        core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::SeqCst);
+        loop {
+            let result = ptr::read_volatile(BASE_ADDRESS.offset(5));
+            if result & 0x20 == 0x20 {
+                break
+            }
+        }
+        core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::SeqCst);
+        ptr::write_volatile(BASE_ADDRESS, ch);
+        core::sync::atomic::compiler_fence(core::sync::atomic::Ordering::SeqCst);
+    }
+}
+
+#[link_section = ".text.init"]
+pub fn machine_debug_puts(s: &str) {
+    let mut sreal = s;
+    if s.as_ptr() as u64 >= 0xffffffff40000000 {
+        unsafe {
+            sreal = core::str::from_utf8_unchecked(core::slice::from_raw_parts(((s.as_ptr() as u64) - 0xffffffff40000000) as *const u8, s.len()));
+        }
+    }
+    for byte in sreal.bytes() {
+        machine_debug_putchar(byte);
+    }
+}
+
+#[link_section = ".text.init"]
+pub fn machine_debug_puthex64(v: u64) {
+    machine_debug_puts("0x");
+    for i in 0 .. 16 {
+        let digit = ((v >> (60 - i * 4)) & 0xF) as u8;
+        if digit >= 0xA {
+            machine_debug_putchar('A' as u8 + digit - 10);
+        } else {
+            machine_debug_putchar('0' as u8 + digit);
+        }
+    }
+}
+
+#[link_section = ".text.init"]
+pub fn machine_debug_putint_recur(v: u64) {
+    if v > 0 {
+        let digit = (v % 10) as u8;
+        machine_debug_putint_recur(v / 10);
+        machine_debug_putchar('0' as u8 + digit);
+    }
+}
+
+#[link_section = ".text.init"]
+pub fn machine_debug_putint(v: u64) {
+    if v == 0 {
+        machine_debug_putchar('0' as u8);
+    } else {
+        machine_debug_putint_recur(v);
+    }
+}
+
+#[link_section = ".text.init"]
+pub fn machine_debug_mark_begin() {
+    machine_debug_puts("\u{1b}[31m");
+}
+
+#[link_section = ".text.init"]
+pub fn machine_debug_mark_end() {
+    machine_debug_puts("\u{1b}[0m");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -25,6 +25,7 @@ mod memory_region;
 mod pfault;
 mod plic;
 mod pmap;
+mod pmp;
 mod sum;
 mod trap;
 mod virtio;

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,6 +20,7 @@ mod context;
 mod csr;
 mod elf;
 mod fdt;
+mod machdebug;
 mod memory_region;
 mod pfault;
 mod plic;

--- a/src/pmp.rs
+++ b/src/pmp.rs
@@ -1,0 +1,155 @@
+
+use crate::machdebug::*;
+
+#[link_section = ".text.init"]
+pub unsafe fn write_pmp_config(entry: u8, config: u8) {
+    machine_debug_assert(0 <= entry && entry <= 15, "entry out of range");
+    let shift = (entry & 7) * 8;
+    if entry < 8 {
+        csrc!(pmpcfg0, (0xFF as u64) << shift);
+        csrs!(pmpcfg0, (config as u64) << shift);
+    } else {
+        csrc!(pmpcfg2, (0xFF as u64) << shift);
+        csrs!(pmpcfg2, (config as u64) << shift);
+    }
+}
+
+#[link_section = ".text.init"]
+pub fn read_pmp_config(entry: u8) -> u8 {
+    machine_debug_assert(0 <= entry && entry <= 15, "entry out of range");
+    let shift = (entry & 7) * 8;
+    let reg = if entry < 8 {
+        csrr!(pmpcfg0)
+    } else {
+        csrr!(pmpcfg2)
+    };
+    (reg >> shift) as u8
+}
+
+#[link_section = ".text.init"]
+pub fn read_pmp_address(entry: u8) -> u64 {
+    match entry {
+        0 => csrr!(pmpaddr0),
+        1 => csrr!(pmpaddr1),
+        2 => csrr!(pmpaddr2),
+        3 => csrr!(pmpaddr3),
+        4 => csrr!(pmpaddr4),
+        5 => csrr!(pmpaddr5),
+        6 => csrr!(pmpaddr6),
+        7 => csrr!(pmpaddr7),
+        8 => csrr!(pmpaddr8),
+        9 => csrr!(pmpaddr9),
+        10 => csrr!(pmpaddr10),
+        11 => csrr!(pmpaddr11),
+        12 => csrr!(pmpaddr12),
+        13 => csrr!(pmpaddr13),
+        14 => csrr!(pmpaddr14),
+        15 => csrr!(pmpaddr15),
+        _ => { machine_debug_abort("entry out of range"); 0 }
+    }
+}
+
+#[link_section = ".text.init"]
+pub unsafe fn write_pmp_address(entry: u8, address: u64) {
+    match entry {
+        0 => csrw!(pmpaddr0, address),
+        1 => csrw!(pmpaddr1, address),
+        2 => csrw!(pmpaddr2, address),
+        3 => csrw!(pmpaddr3, address),
+        4 => csrw!(pmpaddr4, address),
+        5 => csrw!(pmpaddr5, address),
+        6 => csrw!(pmpaddr6, address),
+        7 => csrw!(pmpaddr7, address),
+        8 => csrw!(pmpaddr8, address),
+        9 => csrw!(pmpaddr9, address),
+        10 => csrw!(pmpaddr10, address),
+        11 => csrw!(pmpaddr11, address),
+        12 => csrw!(pmpaddr12, address),
+        13 => csrw!(pmpaddr13, address),
+        14 => csrw!(pmpaddr14, address),
+        15 => csrw!(pmpaddr15, address),
+        _ => { machine_debug_abort("entry out of range"); },
+    }
+}
+
+// note: these updates are not atomic. don't let interrupts happen during them!
+#[link_section = ".text.init"]
+pub unsafe fn install_pmp(entry: u8, config: u8, address: u64) {
+    write_pmp_config(entry, config);
+    machine_debug_assert(read_pmp_config(entry) == config, "could not change PMP config entry");
+    // come up with a better solution to this
+    // (though apparently CSR instructions are hard-coded by CSR, so that might be hard?)
+    write_pmp_address(entry, address);
+}
+
+const PMP_R: u8 = 0x1;
+const PMP_W: u8 = 0x2;
+const PMP_X: u8 = 0x4;
+const PMP_A_SHIFT: u8 = 3;
+const PMP_A_OFF: u8 = 0x0;
+const PMP_A_TOR: u8 = 0x1;
+const PMP_A_NA4: u8 = 0x2;
+const PMP_A_NAPOT: u8 = 0x3;
+const PMP_RES1: u8 = 0x20;
+const PMP_RES2: u8 = 0x40;
+const PMP_LOCK: u8 = 0x80;
+
+/** prints out as much information on the PMP state as possible in M-mode */
+#[link_section = ".text.init"]
+pub fn debug_pmp() {
+    machine_debug_mark_begin();
+    let hart = csrr!(mhartid);
+    machine_debug_puts("=========== PMP CONFIGURATION STATE (hart ");
+    machine_debug_putint(hart);
+    machine_debug_puts(") ==========\n");
+    machine_debug_puts("          R W X AMODE RES1 RES2 LOCK   ADDRESS (raw)\n");
+    for entry in 0..16 {
+        let config = read_pmp_config(entry);
+        let address = read_pmp_address(entry);
+        machine_debug_puts("pmp");
+        machine_debug_putint(entry as u64);
+        if entry < 10 { machine_debug_puts(" "); }
+        machine_debug_puts(" ==> ");
+        if config & PMP_R != 0 {
+            machine_debug_puts("R ");
+        } else {
+            machine_debug_puts("- ");
+        }
+        if config & PMP_W != 0 {
+            machine_debug_puts("W ");
+        } else {
+            machine_debug_puts("- ");
+        }
+        if config & PMP_X != 0 {
+            machine_debug_puts("X ");
+        } else {
+            machine_debug_puts("- ");
+        }
+        match (config >> PMP_A_SHIFT) & 3 {
+            PMP_A_OFF => machine_debug_puts(" OFF  "),
+            PMP_A_TOR => machine_debug_puts(" TOR  "),
+            PMP_A_NA4 => machine_debug_puts(" NA4  "),
+            PMP_A_NAPOT => machine_debug_puts("NAPOT "),
+            _ => unreachable!()
+        };
+        if config & PMP_RES1 != 0 {
+            machine_debug_puts("res1 ");
+        } else {
+            machine_debug_puts("     ");
+        }
+        if config & PMP_RES2 != 0 {
+            machine_debug_puts("res2 ");
+        } else {
+            machine_debug_puts("     ");
+        }
+        if config & PMP_LOCK != 0 {
+            machine_debug_puts("lock ");
+        } else {
+            machine_debug_puts("     ");
+        }
+        machine_debug_puthex64(address);
+        machine_debug_puts("\n");
+    }
+    machine_debug_puts("=============== END CONFIGURATION STATE ===============\n");
+    machine_debug_mark_end();
+}


### PR DESCRIPTION
Assuming that we do a lot of work with PMP configuration, it seems worth having a readily-usable tool to print out the current state. Especially since apparently we can't read CSRs from gdb.

Unfortunately, doing much of anything in machine mode is hard, because most of the rust runtime is linked into the normal .text section where the supervisor code is present, which prevents us from using just about any of it. So here's some dead-simple machine mode debugging tools, all marked as going in .text.init, and some machine-mode PMP helpers as well.

Usage: call `machine_debug_init()` and then `debug_pmp()`. The color is intentionally different from supervisor debug info. Sample output:
![Screenshot_2019-04-17_02-30-00](https://user-images.githubusercontent.com/5056099/56312823-0a86d600-611f-11e9-8b24-4ab6bfdec8fc.png)

There are a number of downsides to this code:
 - This duplicates UART functionality with the supervisor-mode UART driver
 - This only supports the 16550a UART
 - This involves duplicate functionality of parts of the rust runtime (esp. around printing)
 - There's no locking, so trying to debug_pmp() from multiple harts will lead to useless output.

I didn't include this in the previous patchset, because I'm not confident that this should actually be merged into the main development version.

However, since it doesn't require changing any code if you don't use it, there should be no harm in just merging this and deleting it later if it turns out to be useless.